### PR TITLE
Add snapcraft.yaml and snap-utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ yaru-src/
 
 # Cache
 __pycache__
+
+# Snaps
+*.snap

--- a/snap-utils/split-gtk-theme.sh
+++ b/snap-utils/split-gtk-theme.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -eux
+
+basedir="$1"
+gtk2dir="$basedir/share/gtk2"
+themesdir="$basedir/share/themes"
+
+for theme in "$themesdir"/*; do
+    if [ ! -d "$theme" ]; then
+        continue
+    fi
+    themename="$(basename "$theme")"
+    for subdir in "$theme"/gtk-2*; do
+        if [ -d "$subdir" ]; then
+            mkdir -p "$gtk2dir/$themename"
+            mv "$subdir" "$gtk2dir/$themename/"
+        fi
+    done
+done
+

--- a/snap-utils/split-gtk-theme.sh
+++ b/snap-utils/split-gtk-theme.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# This script is from https://github.com/ubuntu-mate/gtk-theme-yaru-mate-snap by Wimpy
 
 set -eux
 

--- a/snap-utils/update-icon-cache.sh
+++ b/snap-utils/update-icon-cache.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -eux
+
+basedir="$1"
+
+# Don't include panel icons to reduce size as they aren't
+# generally useful in the snap.
+if [ -d "$basedir" ]; then
+    find "$basedir" -name panel -exec rm -rf {} +
+fi
+
+for dir in "$basedir"/*/; do
+    if [ -f "$dir/index.theme" ]; then
+        gtk-update-icon-cache -q "$dir"
+    fi
+done

--- a/snap-utils/update-icon-cache.sh
+++ b/snap-utils/update-icon-cache.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# This script is from https://github.com/ubuntu-mate/icon-theme-yaru-mate-snap by Wimpy
 
 set -eux
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,3 +1,5 @@
+# This YAML was forked from https://github.com/ubuntu-mate/gtk-theme-yaru-mate-snap by Wimpy
+
 name: ubuntu-mate-colours
 base: core18
 architectures:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,334 @@
+name: ubuntu-mate-colours
+base: core18
+architectures:
+ - build-on: amd64
+   run-on: all
+version: '21.04.6.4'
+summary: Ubuntu MATE Colours
+description: |
+  A snap containing the colour variations of the Ambiance, Radiance and Yaru themes for Ubuntu MATE. Includes icon themes.
+
+grade: stable
+confinement: strict
+
+slots:
+  gtk-2-themes:
+    interface: content
+    source:
+      read:
+        - $SNAP/share/gtk2/Yaru-MATE-Aqua-dark
+        - $SNAP/share/gtk2/Yaru-MATE-Aqua-light
+        - $SNAP/share/gtk2/Ambiant-MATE-Aqua
+        - $SNAP/share/gtk2/Ambiant-MATE-Dark-Aqua
+        - $SNAP/share/gtk2/Radiant-MATE-Aqua
+        - $SNAP/share/gtk2/Yaru-MATE-Blue-dark
+        - $SNAP/share/gtk2/Yaru-MATE-Blue-light
+        - $SNAP/share/gtk2/Ambiant-MATE-Blue
+        - $SNAP/share/gtk2/Ambiant-MATE-Dark-Blue
+        - $SNAP/share/gtk2/Radiant-MATE-Blue
+        - $SNAP/share/gtk2/Yaru-MATE-Brown-dark
+        - $SNAP/share/gtk2/Yaru-MATE-Brown-light
+        - $SNAP/share/gtk2/Ambiant-MATE-Brown
+        - $SNAP/share/gtk2/Ambiant-MATE-Dark-Brown
+        - $SNAP/share/gtk2/Radiant-MATE-Brown
+        - $SNAP/share/gtk2/Yaru-MATE-Orange-dark
+        - $SNAP/share/gtk2/Yaru-MATE-Orange-light
+        - $SNAP/share/gtk2/Ambiant-MATE-Orange
+        - $SNAP/share/gtk2/Ambiant-MATE-Dark-Orange
+        - $SNAP/share/gtk2/Radiant-MATE-Orange
+        - $SNAP/share/gtk2/Yaru-MATE-Pink-dark
+        - $SNAP/share/gtk2/Yaru-MATE-Pink-light
+        - $SNAP/share/gtk2/Ambiant-MATE-Pink
+        - $SNAP/share/gtk2/Ambiant-MATE-Dark-Pink
+        - $SNAP/share/gtk2/Radiant-MATE-Pink
+        - $SNAP/share/gtk2/Yaru-MATE-Purple-dark
+        - $SNAP/share/gtk2/Yaru-MATE-Purple-light
+        - $SNAP/share/gtk2/Ambiant-MATE-Purple
+        - $SNAP/share/gtk2/Ambiant-MATE-Dark-Purple
+        - $SNAP/share/gtk2/Radiant-MATE-Purple
+        - $SNAP/share/gtk2/Yaru-MATE-Red-dark
+        - $SNAP/share/gtk2/Yaru-MATE-Red-light
+        - $SNAP/share/gtk2/Ambiant-MATE-Red
+        - $SNAP/share/gtk2/Ambiant-MATE-Dark-Red
+        - $SNAP/share/gtk2/Radiant-MATE-Red
+        - $SNAP/share/gtk2/Yaru-MATE-Teal-dark
+        - $SNAP/share/gtk2/Yaru-MATE-Teal-light
+        - $SNAP/share/gtk2/Ambiant-MATE-Teal
+        - $SNAP/share/gtk2/Ambiant-MATE-Dark-Teal
+        - $SNAP/share/gtk2/Radiant-MATE-Teal
+        - $SNAP/share/gtk2/Yaru-MATE-Yellow-dark
+        - $SNAP/share/gtk2/Yaru-MATE-Yellow-light
+        - $SNAP/share/gtk2/Ambiant-MATE-Yellow
+        - $SNAP/share/gtk2/Ambiant-MATE-Dark-Yellow
+        - $SNAP/share/gtk2/Radiant-MATE-Yellow
+  gtk-3-themes:
+    interface: content
+    source:
+      read:
+        - $SNAP/share/themes/Yaru-MATE-Aqua-dark
+        - $SNAP/share/themes/Yaru-MATE-Aqua-light
+        - $SNAP/share/themes/Ambiant-MATE-Aqua
+        - $SNAP/share/themes/Ambiant-MATE-Dark-Aqua
+        - $SNAP/share/themes/Radiant-MATE-Aqua
+        - $SNAP/share/themes/Yaru-MATE-Blue-dark
+        - $SNAP/share/themes/Yaru-MATE-Blue-light
+        - $SNAP/share/themes/Ambiant-MATE-Blue
+        - $SNAP/share/themes/Ambiant-MATE-Dark-Blue
+        - $SNAP/share/themes/Radiant-MATE-Blue
+        - $SNAP/share/themes/Yaru-MATE-Brown-dark
+        - $SNAP/share/themes/Yaru-MATE-Brown-light
+        - $SNAP/share/themes/Ambiant-MATE-Brown
+        - $SNAP/share/themes/Ambiant-MATE-Dark-Brown
+        - $SNAP/share/themes/Radiant-MATE-Brown
+        - $SNAP/share/themes/Yaru-MATE-Orange-dark
+        - $SNAP/share/themes/Yaru-MATE-Orange-light
+        - $SNAP/share/themes/Ambiant-MATE-Orange
+        - $SNAP/share/themes/Ambiant-MATE-Dark-Orange
+        - $SNAP/share/themes/Radiant-MATE-Orange
+        - $SNAP/share/themes/Yaru-MATE-Pink-dark
+        - $SNAP/share/themes/Yaru-MATE-Pink-light
+        - $SNAP/share/themes/Ambiant-MATE-Pink
+        - $SNAP/share/themes/Ambiant-MATE-Dark-Pink
+        - $SNAP/share/themes/Radiant-MATE-Pink
+        - $SNAP/share/themes/Yaru-MATE-Purple-dark
+        - $SNAP/share/themes/Yaru-MATE-Purple-light
+        - $SNAP/share/themes/Ambiant-MATE-Purple
+        - $SNAP/share/themes/Ambiant-MATE-Dark-Purple
+        - $SNAP/share/themes/Radiant-MATE-Purple
+        - $SNAP/share/themes/Yaru-MATE-Red-dark
+        - $SNAP/share/themes/Yaru-MATE-Red-light
+        - $SNAP/share/themes/Ambiant-MATE-Red
+        - $SNAP/share/themes/Ambiant-MATE-Dark-Red
+        - $SNAP/share/themes/Radiant-MATE-Red
+        - $SNAP/share/themes/Yaru-MATE-Teal-dark
+        - $SNAP/share/themes/Yaru-MATE-Teal-light
+        - $SNAP/share/themes/Ambiant-MATE-Teal
+        - $SNAP/share/themes/Ambiant-MATE-Dark-Teal
+        - $SNAP/share/themes/Radiant-MATE-Teal
+        - $SNAP/share/themes/Yaru-MATE-Yellow-dark
+        - $SNAP/share/themes/Yaru-MATE-Yellow-light
+        - $SNAP/share/themes/Ambiant-MATE-Yellow
+        - $SNAP/share/themes/Ambiant-MATE-Dark-Yellow
+        - $SNAP/share/themes/Radiant-MATE-Yellow
+  icon-themes:
+    interface: content
+    source:
+      read:
+        - $SNAP/share/icons/Ambiant-MATE-Aqua
+        - $SNAP/share/icons/Radiant-MATE-Aqua
+        - $SNAP/share/icons/Yaru-MATE-Aqua-dark
+        - $SNAP/share/icons/Yaru-MATE-Aqua-light
+        - $SNAP/share/icons/Ambiant-MATE-Blue
+        - $SNAP/share/icons/Radiant-MATE-Blue
+        - $SNAP/share/icons/Yaru-MATE-Blue-dark
+        - $SNAP/share/icons/Yaru-MATE-Blue-light
+        - $SNAP/share/icons/Ambiant-MATE-Brown
+        - $SNAP/share/icons/Radiant-MATE-Brown
+        - $SNAP/share/icons/Yaru-MATE-Brown-dark
+        - $SNAP/share/icons/Yaru-MATE-Brown-light
+        - $SNAP/share/icons/Ambiant-MATE-Orange
+        - $SNAP/share/icons/Radiant-MATE-Orange
+        - $SNAP/share/icons/Yaru-MATE-Orange-dark
+        - $SNAP/share/icons/Yaru-MATE-Orange-light
+        - $SNAP/share/icons/Ambiant-MATE-Pink
+        - $SNAP/share/icons/Radiant-MATE-Pink
+        - $SNAP/share/icons/Yaru-MATE-Pink-dark
+        - $SNAP/share/icons/Yaru-MATE-Pink-light
+        - $SNAP/share/icons/Ambiant-MATE-Purple
+        - $SNAP/share/icons/Radiant-MATE-Purple
+        - $SNAP/share/icons/Yaru-MATE-Purple-dark
+        - $SNAP/share/icons/Yaru-MATE-Purple-light
+        - $SNAP/share/icons/Ambiant-MATE-Red
+        - $SNAP/share/icons/Radiant-MATE-Red
+        - $SNAP/share/icons/Yaru-MATE-Red-dark
+        - $SNAP/share/icons/Yaru-MATE-Red-light
+        - $SNAP/share/icons/Ambiant-MATE-Teal
+        - $SNAP/share/icons/Radiant-MATE-Teal
+        - $SNAP/share/icons/Yaru-MATE-Teal-dark
+        - $SNAP/share/icons/Yaru-MATE-Teal-light
+        - $SNAP/share/icons/Ambiant-MATE-Yellow
+        - $SNAP/share/icons/Radiant-MATE-Yellow
+        - $SNAP/share/icons/Yaru-MATE-Yellow-dark
+        - $SNAP/share/icons/Yaru-MATE-Yellow-light
+
+parts:
+  utils:
+    plugin: dump
+    source: snap-utils
+    prime:
+      - -*
+    build-packages:
+      - try: [gtk-update-icon-cache]
+      - else: [libgtk-3-bin]
+
+  aqua-themes:
+    after:
+      - utils
+    plugin: dump
+    source: https://launchpad.net/~lah7/+archive/ubuntu/ubuntu-mate-colours/+files/ubuntu-mate-colours-aqua_$SNAPCRAFT_PROJECT_VERSION_all.deb
+    override-build: |
+        snapcraftctl build
+        mkdir -p $SNAPCRAFT_PART_INSTALL/share/themes
+        mkdir -p $SNAPCRAFT_PART_INSTALL/share/icons
+        mv $SNAPCRAFT_PART_INSTALL/usr/share/themes/* $SNAPCRAFT_PART_INSTALL/share/themes/
+        mv $SNAPCRAFT_PART_INSTALL/usr/share/icons/* $SNAPCRAFT_PART_INSTALL/share/icons/
+        $SNAPCRAFT_STAGE/split-gtk-theme.sh $SNAPCRAFT_PART_INSTALL
+        $SNAPCRAFT_STAGE/update-icon-cache.sh $SNAPCRAFT_PART_INSTALL/share/icons
+    stage:
+      - share/gtk2/*/gtk-2.0
+      - share/themes/*/gtk-3*
+      - share/themes/*/gtk-4*
+      - share/icons/*
+
+  blue-themes:
+    after:
+      - utils
+    plugin: dump
+    source: https://launchpad.net/~lah7/+archive/ubuntu/ubuntu-mate-colours/+files/ubuntu-mate-colours-blue_$SNAPCRAFT_PROJECT_VERSION_all.deb
+    override-build: |
+        snapcraftctl build
+        mkdir -p $SNAPCRAFT_PART_INSTALL/share/themes
+        mkdir -p $SNAPCRAFT_PART_INSTALL/share/icons
+        mv $SNAPCRAFT_PART_INSTALL/usr/share/themes/* $SNAPCRAFT_PART_INSTALL/share/themes/
+        mv $SNAPCRAFT_PART_INSTALL/usr/share/icons/* $SNAPCRAFT_PART_INSTALL/share/icons/
+        $SNAPCRAFT_STAGE/split-gtk-theme.sh $SNAPCRAFT_PART_INSTALL
+        $SNAPCRAFT_STAGE/update-icon-cache.sh $SNAPCRAFT_PART_INSTALL/share/icons
+    stage:
+      - share/gtk2/*/gtk-2.0
+      - share/themes/*/gtk-3*
+      - share/themes/*/gtk-4*
+      - share/icons/**
+  
+  brown-themes:
+    after:
+      - utils
+    plugin: dump
+    source: https://launchpad.net/~lah7/+archive/ubuntu/ubuntu-mate-colours/+files/ubuntu-mate-colours-brown_$SNAPCRAFT_PROJECT_VERSION_all.deb
+    override-build: |
+        snapcraftctl build
+        mkdir -p $SNAPCRAFT_PART_INSTALL/share/themes
+        mkdir -p $SNAPCRAFT_PART_INSTALL/share/icons
+        mv $SNAPCRAFT_PART_INSTALL/usr/share/themes/* $SNAPCRAFT_PART_INSTALL/share/themes/
+        mv $SNAPCRAFT_PART_INSTALL/usr/share/icons/* $SNAPCRAFT_PART_INSTALL/share/icons/
+        $SNAPCRAFT_STAGE/split-gtk-theme.sh $SNAPCRAFT_PART_INSTALL
+        $SNAPCRAFT_STAGE/update-icon-cache.sh $SNAPCRAFT_PART_INSTALL/share/icons
+    stage:
+      - share/gtk2/*/gtk-2.0
+      - share/themes/*/gtk-3*
+      - share/themes/*/gtk-4*
+      - share/icons/*
+
+  orange-themes:
+    after:
+      - utils
+    plugin: dump
+    source: https://launchpad.net/~lah7/+archive/ubuntu/ubuntu-mate-colours/+files/ubuntu-mate-colours-orange_$SNAPCRAFT_PROJECT_VERSION_all.deb
+    override-build: |
+        snapcraftctl build
+        mkdir -p $SNAPCRAFT_PART_INSTALL/share/themes
+        mkdir -p $SNAPCRAFT_PART_INSTALL/share/icons
+        mv $SNAPCRAFT_PART_INSTALL/usr/share/themes/* $SNAPCRAFT_PART_INSTALL/share/themes/
+        mv $SNAPCRAFT_PART_INSTALL/usr/share/icons/* $SNAPCRAFT_PART_INSTALL/share/icons/
+        $SNAPCRAFT_STAGE/split-gtk-theme.sh $SNAPCRAFT_PART_INSTALL
+        $SNAPCRAFT_STAGE/update-icon-cache.sh $SNAPCRAFT_PART_INSTALL/share/icons
+    stage:
+      - share/gtk2/*/gtk-2.0
+      - share/themes/*/gtk-3*
+      - share/themes/*/gtk-4*
+      - share/icons/*
+
+  pink-themes:
+    after:
+      - utils
+    plugin: dump
+    source: https://launchpad.net/~lah7/+archive/ubuntu/ubuntu-mate-colours/+files/ubuntu-mate-colours-pink_$SNAPCRAFT_PROJECT_VERSION_all.deb
+    override-build: |
+        snapcraftctl build
+        mkdir -p $SNAPCRAFT_PART_INSTALL/share/themes
+        mkdir -p $SNAPCRAFT_PART_INSTALL/share/icons
+        mv $SNAPCRAFT_PART_INSTALL/usr/share/themes/* $SNAPCRAFT_PART_INSTALL/share/themes/
+        mv $SNAPCRAFT_PART_INSTALL/usr/share/icons/* $SNAPCRAFT_PART_INSTALL/share/icons/
+        $SNAPCRAFT_STAGE/split-gtk-theme.sh $SNAPCRAFT_PART_INSTALL
+        $SNAPCRAFT_STAGE/update-icon-cache.sh $SNAPCRAFT_PART_INSTALL/share/icons
+    stage:
+      - share/gtk2/*/gtk-2.0
+      - share/themes/*/gtk-3*
+      - share/themes/*/gtk-4*
+      - share/icons/*
+
+  purple-themes:
+    after:
+      - utils
+    plugin: dump
+    source: https://launchpad.net/~lah7/+archive/ubuntu/ubuntu-mate-colours/+files/ubuntu-mate-colours-purple_$SNAPCRAFT_PROJECT_VERSION_all.deb
+    override-build: |
+        snapcraftctl build
+        mkdir -p $SNAPCRAFT_PART_INSTALL/share/themes
+        mkdir -p $SNAPCRAFT_PART_INSTALL/share/icons
+        mv $SNAPCRAFT_PART_INSTALL/usr/share/themes/* $SNAPCRAFT_PART_INSTALL/share/themes/
+        mv $SNAPCRAFT_PART_INSTALL/usr/share/icons/* $SNAPCRAFT_PART_INSTALL/share/icons/
+        $SNAPCRAFT_STAGE/split-gtk-theme.sh $SNAPCRAFT_PART_INSTALL
+        $SNAPCRAFT_STAGE/update-icon-cache.sh $SNAPCRAFT_PART_INSTALL/share/icons
+    stage:
+      - share/gtk2/*/gtk-2.0
+      - share/themes/*/gtk-3*
+      - share/themes/*/gtk-4*
+      - share/icons/*
+
+  red-themes:
+    after:
+      - utils
+    plugin: dump
+    source: https://launchpad.net/~lah7/+archive/ubuntu/ubuntu-mate-colours/+files/ubuntu-mate-colours-red_$SNAPCRAFT_PROJECT_VERSION_all.deb
+    override-build: |
+        snapcraftctl build
+        mkdir -p $SNAPCRAFT_PART_INSTALL/share/themes
+        mkdir -p $SNAPCRAFT_PART_INSTALL/share/icons
+        mv $SNAPCRAFT_PART_INSTALL/usr/share/themes/* $SNAPCRAFT_PART_INSTALL/share/themes/
+        mv $SNAPCRAFT_PART_INSTALL/usr/share/icons/* $SNAPCRAFT_PART_INSTALL/share/icons/
+        $SNAPCRAFT_STAGE/split-gtk-theme.sh $SNAPCRAFT_PART_INSTALL
+        $SNAPCRAFT_STAGE/update-icon-cache.sh $SNAPCRAFT_PART_INSTALL/share/icons
+    stage:
+      - share/gtk2/*/gtk-2.0
+      - share/themes/*/gtk-3*
+      - share/themes/*/gtk-4*
+      - share/icons/*
+
+  teal-themes:
+    after:
+      - utils
+    plugin: dump
+    source: https://launchpad.net/~lah7/+archive/ubuntu/ubuntu-mate-colours/+files/ubuntu-mate-colours-teal_$SNAPCRAFT_PROJECT_VERSION_all.deb
+    override-build: |
+        snapcraftctl build
+        mkdir -p $SNAPCRAFT_PART_INSTALL/share/themes
+        mkdir -p $SNAPCRAFT_PART_INSTALL/share/icons
+        mv $SNAPCRAFT_PART_INSTALL/usr/share/themes/* $SNAPCRAFT_PART_INSTALL/share/themes/
+        mv $SNAPCRAFT_PART_INSTALL/usr/share/icons/* $SNAPCRAFT_PART_INSTALL/share/icons/
+        $SNAPCRAFT_STAGE/split-gtk-theme.sh $SNAPCRAFT_PART_INSTALL
+        $SNAPCRAFT_STAGE/update-icon-cache.sh $SNAPCRAFT_PART_INSTALL/share/icons
+    stage:
+      - share/gtk2/*/gtk-2.0
+      - share/themes/*/gtk-3*
+      - share/themes/*/gtk-4*
+      - share/icons/*
+
+  yellow-themes:
+    after:
+      - utils
+    plugin: dump
+    source: https://launchpad.net/~lah7/+archive/ubuntu/ubuntu-mate-colours/+files/ubuntu-mate-colours-yellow_$SNAPCRAFT_PROJECT_VERSION_all.deb
+    override-build: |
+        snapcraftctl build
+        mkdir -p $SNAPCRAFT_PART_INSTALL/share/themes
+        mkdir -p $SNAPCRAFT_PART_INSTALL/share/icons
+        mv $SNAPCRAFT_PART_INSTALL/usr/share/themes/* $SNAPCRAFT_PART_INSTALL/share/themes/
+        mv $SNAPCRAFT_PART_INSTALL/usr/share/icons/* $SNAPCRAFT_PART_INSTALL/share/icons/
+        $SNAPCRAFT_STAGE/split-gtk-theme.sh $SNAPCRAFT_PART_INSTALL
+        $SNAPCRAFT_STAGE/update-icon-cache.sh $SNAPCRAFT_PART_INSTALL/share/icons
+    stage:
+      - share/gtk2/*/gtk-2.0
+      - share/themes/*/gtk-3*
+      - share/themes/*/gtk-4*
+      - share/icons/*
+      


### PR DESCRIPTION
Here's my snapcraft.yaml, along with a couple of scripts borrowed from @flexiondotorg's [Yaru-MATE GTK theme](https://github.com/ubuntu-mate/gtk-theme-yaru-mate-snap) and [icon theme](https://github.com/ubuntu-mate/icon-theme-yaru-mate-snap) snaps. It built successfully, though I haven't tested the snap it produced yet.

Pertains to #27 